### PR TITLE
PR #31: feature: Issue #30: Create "About/Contact/Impressum" page for GitHub pages

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="DE">
+
+<head>
+    <meta charset="UTF-8" />
+    <!--
+:en: GitHub-Pages About/Contact/Impressum page of ComPriFacNot.
+:de: GitHub-Pages About/Contact/Impressum-Seite von ComPriFacNot.
+        
+@author see git history
+@version 1.0, 2021-12-18
+@since 1.0, 2021-12-18
+-->
+    <link rel="stylesheet" type="text/css" href="main.v15.css">
+</head>
+
+<body>
+    <h1><span class="font-weight-normal">📝</span> About/Contact/Impressum</h1>
+
+    <h2><img height="20" width="20"
+            src="https://camo.githubusercontent.com/7a5437b81e4796126f9699bd4ab51324c9c1e309219f06ad763cd3cf645a858b/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f31663165632d31663165372e706e67" />
+        About us/Service provider</h2>
+    <p>
+        ComPriFacNot is an Open-Source-Project, a community of
+        <a href="https://github.com/orgs/ComPriFacNot/people" target="_blank">certain members</a> on the
+        platform <a href="https://github.com" target="_blank">GitHub</a>. The project/the community is
+        represented outwards by the <a href="#Owner">current owner below</a> of the corresponding
+        <a href="https://github.com/ComPriFacNot" target="_blank"> GitHub-organization</a>.
+    </p>
+    <p>
+        The services and contents of the pages beginning with
+        "<code><a href="https://comprifacnot.github.io" target="_blank">https://comprifacnot.github.io</a></code>"
+        (the so-called "GitHub-Pages" of the project/the community) are provided by this project/this
+        community.
+    </p>
+    <h2><img height="20" width="20"
+            src="https://camo.githubusercontent.com/57fa7428fcc2f6d87dbde42422a97d951bd468072accb299ad33b6855aaa7041/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f31663165392d31663165612e706e67" />
+        Über uns/Diensteanbieter</h2>
+    <p>
+        ComPriFacNot ist ein Open-Source-Projekt, eine Gemeinschaft (Community) von
+        <a href="https://github.com/orgs/ComPriFacNot/people" target="_blank">bestimmten Mitgliedern</a> der
+        Plattform <a href="https://github.com" target="_blank">GitHub</a>. Das Projekt/die Community wird
+        nach Außen vertreten durch den <a href="#Owner">unten genannten aktuellen Eigentümer</a> der zugehörigen
+        <a href="https://github.com/ComPriFacNot" target="_blank">GitHub-Organisation</a>.
+    </p>
+    <p>
+        Die auf den Seiten, beginnend mit
+        "<code><a href="https://comprifacnot.github.io" target="_blank">https://comprifacnot.github.io</a></code>"
+        (die sogenannten "GitHub-Pages" des Projektes/der Community) verfügbaren
+        Dienste und Inhalte werden durch dieses Projekt/dieses Community angeboten.
+    </p>
+    <h2 id="Owner"><img height="20" width="20"
+            src="https://camo.githubusercontent.com/7a5437b81e4796126f9699bd4ab51324c9c1e309219f06ad763cd3cf645a858b/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f31663165632d31663165372e706e67" />
+        Owner/<img height="20" width="20"
+            src="https://camo.githubusercontent.com/57fa7428fcc2f6d87dbde42422a97d951bd468072accb299ad33b6855aaa7041/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f31663165392d31663165612e706e67" />
+        Eigentümer</h2>
+
+    <table border="1">
+        <thead>
+            <tr>
+                <th><img height="20" width="20"
+                        src="https://camo.githubusercontent.com/7a5437b81e4796126f9699bd4ab51324c9c1e309219f06ad763cd3cf645a858b/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f31663165632d31663165372e706e67" />
+                    ?</th>
+                <th><img height="20" width="20"
+                        src="https://camo.githubusercontent.com/57fa7428fcc2f6d87dbde42422a97d951bd468072accb299ad33b6855aaa7041/68747470733a2f2f6769746875622e6769746875626173736574732e636f6d2f696d616765732f69636f6e732f656d6f6a692f756e69636f64652f31663165392d31663165612e706e67" />
+                    ?</th>
+                <th>!</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Legal form</td>
+                <td></td>
+                <td>Natural person</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>Rechtsform</td>
+                <td>Natürliche Person</td>
+            </tr>
+            <tr>
+                <td>Name</td>
+                <td>Name</td>
+                <td>Stefan Leder</td>
+            </tr>
+            <tr>
+                <td>Address</td>
+                <td>Anschrift</td>
+                <td>Friesenstraße 46<br />D-30161 Hannover</td>
+            </tr>
+            <tr>
+                <td>Member state of the head office</td>
+                <td></td>
+                <td>Lower saxony (Germany)</td>
+            </tr>
+            <tr>
+                <td> </td>
+                <td>Sitzland</td>
+                <td>Niedersachsen (Deutschland)</td>
+            </tr>
+            <tr>
+                <td>📧 eMail</td>
+                <td>📧 E-Mail</td>
+                <td><a href="mailto:stefan@leder.net"><code>stefan@leder.net</code></a></td>
+            </tr>
+            <tr>
+                <td>GitHub user</td>
+                <td>GitHub-User</td>
+                <td><a href="https://github.com/Stefan-Leder-net" target="_blank"><code>Stefan-Leder-net</code></a></td>
+            </tr>
+            <tr>
+                <td>Competent regulatory and supervisory authority</td>
+                <td>Zuständige Regulierungs- und Aufsichtsbehörde</td>
+                <td><a href="https://www.nlm.de/">Niedersächsische Landesmedienanstalt (NLM)</a></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <p>
+        <a href="index.htm">🔙 Back/Zurück</a> 
+        &nbsp;<a href="togithub.htm?to=/blob/main/docs/about.htm" 
+            target="_blank">&lt; &gt; Source code</a>
+    </p>    
+        
+</body>
+
+</html>

--- a/docs/index.htm
+++ b/docs/index.htm
@@ -6,10 +6,10 @@
 GitHub-Pages-Startseite von ComPriFacNot.
 
 @author see git history
-@version 1.7, 2021-12-16
+@version 1.8, 2021-12-18
 @since 1.0, 2021-11-30
 -->
-<link rel="stylesheet" type="text/css" href="main.v14.css">
+<link rel="stylesheet" type="text/css" href="main.v15.css">
 </head>
 <body>
 <h1>GitHub Pages</h1>
@@ -30,8 +30,9 @@ Willkommen bei den GitHub-Pages von ComPriFacNot!
 
 <p>
 <a href="togithub.htm">🔙 Back/Zurück</a> 
-<a href="togithub.htm?to=/blob/main/docs/index.htm" 
+&nbsp;<a href="togithub.htm?to=/blob/main/docs/index.htm" 
     target="_blank">&lt; &gt; Source code</a>
+&nbsp;<a href="about.html">📝 About/Contact/Impressum</a>
 </p>    
 </body>
 </html>

--- a/docs/javascript/PrimeFactoredIntegerTest.htm
+++ b/docs/javascript/PrimeFactoredIntegerTest.htm
@@ -8,7 +8,7 @@
     PrimeFactoredIntegerFormatter
 
     @author see git history
-    @version 2.1, 2021-12-16
+    @version 2.2, 2021-12-18
     @since 1.0, 2021-11-29
 -->
     <script id="scriptBasicDigits" type="application/ld+json" src="basic-digits.jsonc"></script>
@@ -21,7 +21,7 @@
     <script src="generated/TestRun.js"></script>
     <script src="generated/PrimeFactoredIntegerTestSuite.js"></script>
     <script src="generated/PrimeFactoredIntegerTest.js" defer></script>
-    <link rel="stylesheet" type="text/css" href="main.v14.css">
+    <link rel="stylesheet" type="text/css" href="main.v15.css">
 </head>
 
 <body>
@@ -129,7 +129,7 @@
     </div>
     <h2>Test cases</h2>
     <form id="formTestCases" action="PrimeFactoredIntegerTest.htm">
-        <table border="1">
+        <table id="tableTestCases" border="1">
             <thead>
                 <tr>
                     <th id="thInverse" class="cursor-pointer">◪</th>
@@ -142,8 +142,6 @@
                     <th>Match</th>
                 </tr>
             </thead>
-            <tbody id="tbodyTestCases">
-            </tbody>
         </table>
         <p>
             <input type="submit" value="Run selected test case(s)"></input>
@@ -151,13 +149,21 @@
         </p>
     </form>
     <p>
-        <a href="../index.htm">🔙 Back/Zurück</a>&nbsp;
-        <a href="../togithub.htm?to=/blob/main/docs/javascript/PrimeFactoredIntegerTest.htm" target="_blank">&lt; &gt;
-            Source code</a>
         <br /><!-- To ensure the visibility of the previous paragraph because of the divStatusBar -->
         &nbsp;
+        <br />
+        &nbsp;
     </p>
-    <div id="divStatusBar" class="footer monospace">&nbsp;</div>
+    <footer>
+        <br />
+        <a href="../index.htm">🔙 Back/Zurück</a>
+        &nbsp;<a href="../togithub.htm?to=/blob/main/docs/javascript/PrimeFactoredIntegerTest.htm" target="_blank">&lt;
+            &gt; Source code</a>
+        &nbsp;<a href="../about.html">📝 About/Contact/Impressum</a>
+        <br />
+        &nbsp;
+        <div id="divStatusBar" class="background-color-whitesmoke monospace">&nbsp;</div>
+    </footer>
 </body>
 
 </html>

--- a/docs/javascript/generated/PrimeFactoredIntegerTest.js
+++ b/docs/javascript/generated/PrimeFactoredIntegerTest.js
@@ -3,7 +3,7 @@
  * :de: JavaScript für Seite PrimeFactoredIntegerTest.htm.
  *
  * @author See git history
- * @version 1.9, 2021-12-17
+ * @version 2.0, 2021-12-18
  * @since 1.0, 2021-11-29
  */
 "use strict";
@@ -147,7 +147,7 @@ function onTestCaseInputClick(pvMouseEvent) {
 function setStatus(pvText) {
     STATUS_BAR_ELEMENT.innerText = pvText;
 }
-const TEST_CASES_ID = "tbodyTestCases";
+const TEST_CASES_ID = "tableTestCases";
 const TEST_CASES_ELEMENT = document.getElementById(TEST_CASES_ID);
 const QUERY_PARAM_TEST_CASE_ID = (QUERY_PARAMS == null) ? null : QUERY_PARAMS.getAll(TEST_CASE_ID_NAME);
 const TEST_ALL = (QUERY_PARAM_TEST_CASE_ID == null)
@@ -220,6 +220,7 @@ function onAfterConceptInitialized() {
             const lcTestCase = lcEntry[1];
             const lcChecked = (QUERY_PARAM_TEST_CASE_ID == null)
                 ? false : (TEST_ALL || QUERY_PARAM_TEST_CASE_ID.includes(lcTestCaseId));
+            const lcTbodyElement = document.createElement("tbody");
             const lcTrElement = document.createElement("tr");
             const lcTdSelectionElement = document.createElement("td");
             const lcInputElement = document.createElement("input");
@@ -304,7 +305,8 @@ function onAfterConceptInitialized() {
                 (lcChecked ? (" background-color-" +
                     (lvMatch ? CSS_CLASS_MATCH : CSS_CLASS_NOMATCH)) : "");
             lcTrElement.appendChild(lcTdMatchElement);
-            TEST_CASES_ELEMENT.appendChild(lcTrElement);
+            lcTbodyElement.appendChild(lcTrElement);
+            TEST_CASES_ELEMENT.appendChild(lcTbodyElement);
         }
     }
 }

--- a/docs/javascript/main.v14.css
+++ b/docs/javascript/main.v14.css
@@ -1,1 +1,0 @@
-@import "../main.v14.css";

--- a/docs/javascript/main.v15.css
+++ b/docs/javascript/main.v15.css
@@ -1,0 +1,1 @@
+@import "../main.v15.css";

--- a/docs/main.v15.css
+++ b/docs/main.v15.css
@@ -4,9 +4,22 @@
  * Haupt-Stylesheets.
  * 
  * @author see git history
- * @version 1.4, 2021-12-14
+ * @version 1.5, 2021-12-18
  * @since 1.0, 2021-11-30
  */
+
+@media screen {
+
+    footer {
+        background-color: white;
+        border-top: thin solid lightgray;
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+    }    
+
+}
 
 a {
     text-decoration: none;
@@ -20,12 +33,12 @@ h1, h2, h3, h4, h5, h6 {
     font-family: "Arial Black";
 }
     
-html {
-    font-family: Arial, Helvetica, sans-serif;
-}
-
 summary {
 	cursor: pointer;
+}
+
+tbody {
+    break-inside: avoid !important;
 }
 
 th {
@@ -55,6 +68,10 @@ tr {
     background-color: red;
 }
 
+.background-color-whitesmoke {
+    background-color: whitesmoke;
+}
+
 .cursor-help {
     cursor: help;
 }
@@ -67,12 +84,12 @@ tr {
     font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Cambria Math", fantasy;
 }
 
-.footer {
-    background-color: whitesmoke;
-	position: fixed;
-	left: 0;
-	bottom: 0;
-	width: 100%;
+.font-sans-seif, html {
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.font-weight-normal {
+    font-weight: normal;
 }
 
 .monospace {

--- a/typescript/src/PrimeFactoredIntegerTest.ts
+++ b/typescript/src/PrimeFactoredIntegerTest.ts
@@ -3,7 +3,7 @@
  * :de: JavaScript für Seite PrimeFactoredIntegerTest.htm.
  * 
  * @author See git history
- * @version 1.9, 2021-12-17
+ * @version 2.0, 2021-12-18
  * @since 1.0, 2021-11-29
  */
 
@@ -163,7 +163,7 @@ function setStatus(pvText: string) {
     STATUS_BAR_ELEMENT.innerText = pvText;
 }
 
-const TEST_CASES_ID = "tbodyTestCases";
+const TEST_CASES_ID = "tableTestCases";
 const TEST_CASES_ELEMENT = document.getElementById(TEST_CASES_ID);
 const QUERY_PARAM_TEST_CASE_ID =
     (QUERY_PARAMS == null) ? null : QUERY_PARAMS.getAll(TEST_CASE_ID_NAME);
@@ -250,6 +250,7 @@ function onAfterConceptInitialized() {
             const lcTestCase = lcEntry[1];
             const lcChecked = (QUERY_PARAM_TEST_CASE_ID == null)
                 ? false : (TEST_ALL || QUERY_PARAM_TEST_CASE_ID.includes(lcTestCaseId));
+            const lcTbodyElement = document.createElement("tbody");
             const lcTrElement = document.createElement("tr");
             const lcTdSelectionElement = document.createElement("td");
             const lcInputElement = document.createElement("input");
@@ -333,7 +334,8 @@ function onAfterConceptInitialized() {
                 (lcChecked ? (" background-color-" +
                     (lvMatch ? CSS_CLASS_MATCH : CSS_CLASS_NOMATCH)) : "");
             lcTrElement.appendChild(lcTdMatchElement);
-            TEST_CASES_ELEMENT.appendChild(lcTrElement);
+            lcTbodyElement.appendChild(lcTrElement);
+            TEST_CASES_ELEMENT.appendChild(lcTbodyElement);
         }
     }
 }


### PR DESCRIPTION
Issue #30: [FEATURE] Create about/contact/impressum page and include link to it on all GitHub pages

# Pull request #

## Triggered/related issue(s) ##

References to triggered/related issue(s) in this repository:

- #30 

## Summary of proposed changes ##

A description of the changes proposed in the pull request:

Create an "About/Contact/Impressum" page at the GitHub pages.

## Quality checks ##

Actions taken to improve the quality of the changes - *mark with (x)*:

- Java files
  - ( ) CheckStyle
  - ( ) FindBugs/SpotBugs
  - ( ) IntelliJ IDEA Code inspector
- JavaScript files
  - (x) VS Code checks
- MarkDown files
  - ( ) Markdownlint checks

## Tests ##

Ran Test cases - *mark (x) and fill out*:

- ( ) Documented in issue #...
- (x) Documented as follows:

[2021-12-18 PrimeFactoredIntegerTest.pdf](https://github.com/ComPriFacNot/ComPriFacNot/files/7739934/2021-12-18.PrimeFactoredIntegerTest.pdf)

## Recommended reviewers ##

@mentions of the recommended person(s) or team(s) responsible for reviewing proposed changes:

No reviewer (emergeny pull).

## Remarks ##

Further Remarks:

./.